### PR TITLE
feat: Replace 'Nosotros' section with 'Noticias' section

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -123,7 +123,7 @@
 
     <!-- Menú centrado -->
     <ul class="nav school-nav mx-auto">
-      <li class="nav-item"><a class="nav-link" href="#nosotros">Nosotros</a></li>
+      <li class="nav-item"><a class="nav-link" href="#noticias">Noticias</a></li>
       <li class="nav-item"><a class="nav-link" href="#cultura">Cultura</a></li>
       <li class="nav-item"><a class="nav-link" href="#bienestar">Bienestar</a></li>
       <li class="nav-item"><a class="nav-link" href="#mision">Misión y Visión</a></li>

--- a/core/templates/inicio.html
+++ b/core/templates/inicio.html
@@ -74,20 +74,40 @@
   </button>
 </div>
 
-<!-- Sección Nosotros -->
-<section id="nosotros" class="d-flex align-items-center min-vh-100 bg-light">
+<!-- Sección Noticias -->
+<section id="noticias" class="d-flex align-items-center min-vh-100 bg-light">
   <div class="container">
-    <div class="row align-items-center">
-      <div class="col-md-6" data-aos="fade-right">
-        <img src="https://picsum.photos/600/400?random=11" alt="Nosotros" class="img-fluid rounded-4 shadow">
+    <h2 class="fw-bold text-success mb-5 text-center">Últimas Noticias</h2>
+    <div class="row g-4">
+      <div class="col-md-4">
+        <div class="card h-100 shadow-sm">
+          <img src="https://picsum.photos/400/250?random=1" class="card-img-top" alt="Noticia 1">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title fw-bold">Nueva Cosecha en el Huerto Escolar</h5>
+            <p class="card-text text-secondary">Nuestros estudiantes de primaria celebraron la cosecha de vegetales orgánicos en el huerto escolar, un proyecto que fomenta la sostenibilidad y el trabajo en equipo.</p>
+            <a href="#" class="btn btn-success mt-auto align-self-start">Leer más</a>
+          </div>
+        </div>
       </div>
-      <div class="col-md-6 ps-lg-5 text-center text-md-start" data-aos="fade-left">
-        <h2 class="fw-bold text-success mb-4">Nosotros</h2>
-        <p class="lead text-secondary mb-4">
-          Somos una institución educativa que impulsa el desarrollo académico y humano. 
-          Nos enfocamos en formar estudiantes que marquen la diferencia en sus comunidades.
-        </p>
-        <a href="#cultura" class="btn btn-success btn-lg px-4">Descubre más</a>
+      <div class="col-md-4">
+        <div class="card h-100 shadow-sm">
+          <img src="https://picsum.photos/400/250?random=2" class="card-img-top" alt="Noticia 2">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title fw-bold">Competencia de Robótica a Nivel Nacional</h5>
+            <p class="card-text text-secondary">El equipo de robótica de nuestra escuela obtuvo el primer lugar en la competencia nacional, demostrando su ingenio y habilidades en programación.</p>
+            <a href="#" class="btn btn-success mt-auto align-self-start">Leer más</a>
+          </div>
+        </div>
+      </div>
+      <div class="col-md-4">
+        <div class="card h-100 shadow-sm">
+          <img src="https://picsum.photos/400/250?random=3" class="card-img-top" alt="Noticia 3">
+          <div class="card-body d-flex flex-column">
+            <h5 class="card-title fw-bold">Intercambio Cultural con Escuela de Verano</h5>
+            <p class="card-text text-secondary">Recibimos a estudiantes de intercambio para un programa de verano lleno de actividades culturales, deportivas y académicas que enriquecieron a toda nuestra comunidad.</p>
+            <a href="#" class="btn btn-success mt-auto align-self-start">Leer más</a>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This change replaces the 'Nosotros' (About Us) section with a new 'Noticias' (News) section on the homepage. The new section features a card-based layout with placeholder content for news articles.

The navigation bar has also been updated to link to the new 'Noticias' section.