### PR TITLE
Eliminar la barra de navegación del panel del coordinador

### DIFF
--- a/core/templates/base.html
+++ b/core/templates/base.html
@@ -107,6 +107,7 @@
 
 <body class="{% block body_class %}{% endblock %}">
 
+  {% block navbar %}
   <!-- NAVBAR -->
   <div class="container school-navbar d-flex align-items-center justify-content-between rounded-pill mt-4">
 
@@ -177,6 +178,7 @@
       {% endif %}
     </div>
   </div>
+  {% endblock %}
 
   <!-- Modal Login -->
   <div class="modal fade" id="loginModal" tabindex="-1" aria-hidden="true">

--- a/core/templates/panel_coordinador/dashboard_base.html
+++ b/core/templates/panel_coordinador/dashboard_base.html
@@ -1,6 +1,15 @@
 {% extends "base.html" %}
 {% load static %}
 
+{% block navbar %}
+{% comment %}
+  Este bloque está intencionadamente vacío para eliminar la barra de navegación
+  en el panel del coordinador. La barra de navegación principal se encuentra en
+  la plantilla `base.html`, pero al sobreescribir el bloque `navbar` con un
+  bloque vacío, evitamos que se renderice en las páginas que heredan de
+  esta plantilla.
+{% endcomment %}
+{% endblock %}
 
 {% block content %}
 <div class="container-fluid mt-4">


### PR DESCRIPTION
Se ha eliminado la barra de navegación del panel del coordinador para simplificar la interfaz y centrarse en las herramientas de gestión.

Para lograr esto, se ha utilizado la herencia de plantillas de Django:
1.  Se ha envuelto la barra de navegación en `core/templates/base.html` con un bloque `{% block navbar %}`.
2.  Se ha sobreescrito este bloque con uno vacío en `core/templates/panel_coordinador/dashboard_base.html`, que es la plantilla base para el panel del coordinador.

Esto asegura que la barra de navegación se elimine únicamente del panel del coordinador sin afectar al resto del sitio.