### PR TITLE
The coordinator's dashboard had a layout issue where the side panel a…

### DIFF
--- a/core/static/css/dashboard_base.css
+++ b/core/static/css/dashboard_base.css
@@ -1,6 +1,5 @@
 .dashboard-panel-content {
   background: #f5f8fb;
-  min-height: 100vh;
   padding: 2rem 0 0 0;
   transition: background 0.2s;
 }

--- a/core/templates/includes/aside_coordinador.html
+++ b/core/templates/includes/aside_coordinador.html
@@ -1,7 +1,7 @@
 {% load static %}
 
 
-<div class="bg-success text-white p-7 min-vh-100">
+<div class="bg-success text-white p-7">
 
    <div class="d-flex align-items-center gap-8 mb-4 ps-5">
   <img src="{% static 'img/imag.jpg' %}" alt="imag" class="rounded-circle border shadow" style="width: 130px; height: 130px;">

--- a/core/templates/panel_coordinador/dashboard_base.html
+++ b/core/templates/panel_coordinador/dashboard_base.html
@@ -100,8 +100,7 @@
       </div>
 
     </div> {% block panel_content %}{% endblock %}
-    
-    {% endblock %}
   </div>
 </div>
+{% endblock %}
 


### PR DESCRIPTION
…nd footer would overlap with the main content.

This was caused by a combination of a template syntax error and conflicting CSS height properties.

This commit fixes the issue by:
- Correcting the `endblock` tag placement in `dashboard_base.html`.
- Removing `min-vh-100` from the aside panel's template.
- Removing `min-height: 100vh` from the dashboard's CSS.

These changes ensure the dashboard content correctly inherits the flexbox layout from the base template, resulting in a seamless, non-overlapping page. The original content and functionality of the dashboard are preserved.